### PR TITLE
Make it work with esp-idf as of 230216

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ In `esp32_build_config.rb`, at the end of the `MRuby::CrossBuild` block, add the
   conf.gem :github => 'mruby-esp32/mruby-esp32-gpio'
 ```
 
+In `CMakeLists.txt`, make sure the line `PRIV_REQUIRES` includes the `driver` component. Add it if needed:
+
+```
+  add_prebuilt_library(
+    libmruby ${LIBMRUBY_FILE}
+    PRIV_REQUIRES esp_wifi esp_hw_support esp_rom mqtt driver 
+  )
+````
+
 ## Example
 ```ruby
 include ESP32::GPIO

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ mruby-esp32-gpio
 GPIO library for mruby-esp32.
 
 ## Installation
-Add the line below to your `build_config.rb`:
+In `esp32_build_config.rb`, at the end of the `MRuby::CrossBuild` block, add the following:
 
 ```ruby
   conf.gem :github => 'mruby-esp32/mruby-esp32-gpio'

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -8,7 +8,6 @@ module ESP32
       alias :analog_write  :analogWrite   
       alias :analog_read   :analogRead    
       alias :pin_mode      :pinMode 
-      alias :hall_read     :hallRead   
     end  
   
     class Pin

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -24,7 +24,7 @@ mrb_esp32_gpio_pin_mode(mrb_state *mrb, mrb_value self) {
     return mrb_nil_value();
   }
 
-  gpio_pad_select_gpio(mrb_fixnum(pin));
+  esp_rom_gpio_pad_select_gpio(mrb_fixnum(pin));
   gpio_set_direction(mrb_fixnum(pin), mrb_fixnum(dir) & ~GPIO_MODE_DEF_PULLUP);
 
   if (mrb_fixnum(dir) & GPIO_MODE_DEF_PULLUP) {
@@ -89,14 +89,9 @@ mrb_esp32_gpio_analog_read(mrb_state *mrb, mrb_value self) {
     return mrb_nil_value();
   }
 
-  adc1_config_channel_atten(mrb_fixnum(ch), ADC_ATTEN_11db);
+  adc1_config_channel_atten(mrb_fixnum(ch), ADC_ATTEN_DB_11);
 
   return mrb_fixnum_value(adc1_get_raw(mrb_fixnum(ch)));
-}
-
-static mrb_value
-mrb_esp32_gpio_hall_read(mrb_state *mrb, mrb_value self) {
-  return mrb_fixnum_value(hall_sensor_read());
 }
 
 void
@@ -112,9 +107,8 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
-  mrb_define_module_function(mrb, gpio, "hallRead", mrb_esp32_gpio_hall_read, MRB_ARGS_NONE());
-
-  adc1_config_width(ADC_WIDTH_12Bit);
+  
+  adc1_config_width(ADC_BITWIDTH_12);
 
   constants = mrb_define_module_under(mrb, gpio, "Constants");
 
@@ -162,9 +156,8 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   define_const(GPIO_NUM_39);
   define_const(GPIO_NUM_MAX);
 
-  define_const(DAC_CHANNEL_1);
-  define_const(DAC_CHANNEL_2);
-  define_const(DAC_CHANNEL_MAX);
+  define_const(DAC_CHAN_0);
+  define_const(DAC_CHAN_1);
 
   define_const(ADC1_CHANNEL_0);
   define_const(ADC1_CHANNEL_1);


### PR DESCRIPTION
I tried adding this to the basic example in [mruby-esp32](https://github.com/mruby-esp32/mruby-esp32), but couldn't get it working, even with the esp-idf 5.0 release specified there.

After searching the esp-idf docs for the compiler errors, these were the changes needed to get it working with `esp-idf:master`. It's mostly name changes and removing hall effect support, which they've removed the API for.

There are still a ton of notes and deprecation warnings during compile, but at least it works for now. Also, I'm not sure if manually adding `driver` to `CMakeLists.txt` is the right way to go about it, but without that, it wouldn't find any of the `driver/` header files.
