### PR TITLE
Remove analog_read, analog_write, hall_read.

### DIFF
--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -5,10 +5,7 @@ module ESP32
     class << self
       alias :digital_write :digitalWrite   
       alias :digital_read  :digitalRead
-      alias :analog_write  :analogWrite   
-      alias :analog_read   :analogRead    
       alias :pin_mode      :pinMode 
-      alias :hall_read     :hallRead   
     end  
   
     class Pin
@@ -27,18 +24,10 @@ module ESP32
         self.mode= mode
       end
   
-      def analog_read
-        GPIO.analog_read pin
-      end
-    
       def read
         GPIO.digital_read pin
       end 
      
-      def analog_write val
-        GPIO.analog_write pin, val
-      end
-    
       def write val
         GPIO.digital_write pin, val
         val


### PR DESCRIPTION
I removed three methods: analog_read, analog_write, and hall_read.

## analog_read and analog_write

The C API for ADC and DAC has redesigned significantly in ESP-EDF v5.0. I have determined that this makes it difficult to continue to provide functionality with the current interfaces.

DAC, ADC will be provided as separate mrbgems with different interfaces.

https://github.com/espressif/esp-idf/blob/master/docs/en/migration-guides/release-5.x/5.0/peripherals.rst#adc-oneshot--continuous-mode-drivers

## hall_read

This is because the C API, hall_sensor_read(), was removed in ESP-IDF v5.0.
It also says "Hall sensor is no longer supported on ESP32."

https://github.com/espressif/esp-idf/blob/master/docs/en/migration-guides/release-5.x/5.0/peripherals.rst#api-changes