### PR TITLE
Replace undefined constants DAC_CHAN_0 and DAC_CHAN_1.

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -156,8 +156,8 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   define_const(GPIO_NUM_39);
   define_const(GPIO_NUM_MAX);
 
-  define_const(DAC_CHAN_0);
-  define_const(DAC_CHAN_1);
+  define_const(DAC_CHANNEL_1);
+  define_const(DAC_CHANNEL_2);
 
   define_const(ADC1_CHANNEL_0);
   define_const(ADC1_CHANNEL_1);


### PR DESCRIPTION
DAC_CHAN_0 and DAC_CHAN_1 is undefined in ESP-IDF v5.0.

https://github.com/mruby-esp32/mruby-esp32/actions/runs/4273400170/jobs/7439286258

I replaced them with new constants DAC_CHANNEL_1 and DAC_CHANNEL_2.