### PR TITLE
Constants under ESP32 instead of GPIO module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In `CMakeLists.txt`, make sure the line `PRIV_REQUIRES` includes the `driver` co
 
 ## Example
 ```ruby
+include ESP32::Constants
 include ESP32::GPIO
 
 led = GPIO_NUM_4

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -1,7 +1,7 @@
 module ESP32
+  include Constants
+  
   module GPIO
-    include Constants
-    
     class << self
       alias :digital_write :digitalWrite   
       alias :digital_read  :digitalRead
@@ -12,11 +12,11 @@ module ESP32
   
     class Pin
       PIN_MODE = {
-        pullup:   ESP32::GPIO::INPUT_PULLUP,
-        pulldown: ESP32::GPIO::INPUT_PULLDOWN,
-        input:    ESP32::GPIO::INPUT,
-        output:   ESP32::GPIO::OUTPUT,
-        inout:    ESP32::GPIO::INPUT_OUTPUT
+        pullup:   ESP32::GPIO_MODE_INPUT_PULLUP,
+        pulldown: ESP32::GPIO_MODE_INPUT_PULLDOWN,
+        input:    ESP32::GPIO_MODE_INPUT,
+        output:   ESP32::GPIO_MODE_OUTPUT,
+        inout:    ESP32::GPIO_MODE_INPUT_OUTPUT
       }
 
       attr_reader :pin

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -2,6 +2,12 @@ module ESP32
   include Constants
   
   module GPIO
+    INPUT_PULLUP   = ESP32::GPIO_MODE_INPUT_PULLUP
+    INPUT_PULLDOWN = ESP32::GPIO_MODE_INPUT_PULLDOWN
+    INPUT          = ESP32::GPIO_MODE_INPUT
+    OUTPUT         = ESP32::GPIO_MODE_OUTPUT
+    INPUT_OUTPUT   = ESP32::GPIO_MODE_INPUT_OUTPUT
+    
     class << self
       alias :digital_write :digitalWrite   
       alias :digital_read  :digitalRead

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -110,7 +110,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   
   adc1_config_width(ADC_BITWIDTH_12);
 
-  constants = mrb_define_module_under(mrb, gpio, "Constants");
+  constants = mrb_define_module_under(mrb, esp32, "Constants");
 
 #define define_const(SYM) \
   do { \
@@ -172,11 +172,11 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   mrb_define_const(mrb, constants, "LOW", mrb_fixnum_value(0));
   mrb_define_const(mrb, constants, "HIGH", mrb_fixnum_value(1));
 
-  mrb_define_const(mrb, constants, "INPUT",          mrb_fixnum_value(GPIO_MODE_INPUT));
-  mrb_define_const(mrb, constants, "INPUT_OUTPUT",   mrb_fixnum_value(GPIO_MODE_INPUT_OUTPUT));
-  mrb_define_const(mrb, constants, "OUTPUT",         mrb_fixnum_value(GPIO_MODE_OUTPUT));
-  mrb_define_const(mrb, constants, "INPUT_PULLUP",   mrb_fixnum_value(GPIO_MODE_INPUT_PULLUP));
-  mrb_define_const(mrb, constants, "INPUT_PULLDOWN", mrb_fixnum_value(GPIO_MODE_INPUT_PULLDOWN));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT",          mrb_fixnum_value(GPIO_MODE_INPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_OUTPUT",   mrb_fixnum_value(GPIO_MODE_INPUT_OUTPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_OUTPUT",         mrb_fixnum_value(GPIO_MODE_OUTPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_PULLUP",   mrb_fixnum_value(GPIO_MODE_INPUT_PULLUP));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_PULLDOWN", mrb_fixnum_value(GPIO_MODE_INPUT_PULLDOWN));
     
 }
 


### PR DESCRIPTION
Since all of the names defined in the esp-idf already have component names prefixed, like `GPIO_*`, `LEDC_*` etc., they read better if all are defined at the top level of the `ESP32` module. This also makes them consistent with the esp-idf documentation.

Example: `ESP32::GPIO_NUM2` instead of `ESP32::GPIO::GPIO_NUM2`, when used from outside the scope of the `GPIO` module.

To fix scripts that top level include `GPIO`, add `include ESP32::Constants`.