### PR TITLE
Declare both styles of GPIO method names in C

### DIFF
--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -3,11 +3,11 @@ module ESP32
     include Constants
     
     class << self
-      alias :digital_write :digitalWrite   
-      alias :digital_read  :digitalRead
-      alias :analog_write  :analogWrite   
-      alias :analog_read   :analogRead    
-      alias :pin_mode      :pinMode 
+      alias :pinMode      :pin_mode      
+      alias :digitalWrite :digital_write 
+      alias :digitalRead  :digital_read  
+      alias :analogWrite  :analog_write  
+      alias :analogRead   :analog_read   
     end  
   
     class Pin

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -2,14 +2,6 @@ module ESP32
   module GPIO
     include Constants
     
-    class << self
-      alias :pinMode      :pin_mode      
-      alias :digitalWrite :digital_write 
-      alias :digitalRead  :digital_read  
-      alias :analogWrite  :analog_write  
-      alias :analogRead   :analog_read   
-    end  
-  
     class Pin
       PIN_MODE = {
         pullup:   ESP32::GPIO::INPUT_PULLUP,

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -102,11 +102,19 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   esp32 = mrb_define_module(mrb, "ESP32");
 
   gpio = mrb_define_module_under(mrb, esp32, "GPIO");
+  // Ruby-style snake case methods.
   mrb_define_module_function(mrb, gpio, "pin_mode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digital_write", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digital_read", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, gpio, "analog_write", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "analog_read", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
+
+  // Arduino-style camel case methods.
+  mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   
   adc1_config_width(ADC_BITWIDTH_12);
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -112,7 +112,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   // Arduino-style camel case methods.
   mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -102,11 +102,11 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   esp32 = mrb_define_module(mrb, "ESP32");
 
   gpio = mrb_define_module_under(mrb, esp32, "GPIO");
-  mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
-  mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, gpio, "pin_mode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digital_write", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digital_read", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, gpio, "analog_write", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analog_read", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   
   adc1_config_width(ADC_BITWIDTH_12);
 


### PR DESCRIPTION
I'm not sure why, but the aliased snake-case methods weren't available when top-level including `ESP32::GPIO` in a script. So the Arduino-ish camel-case `pinMode` worked, but not `pin_mode` for example.

By defining both styles in C, we can use either at the top level of a script, although I think snake-case should be encouraged, since it's the default style for Ruby.