### PR TITLE
Support for more variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In `CMakeLists.txt`, make sure the line `PRIV_REQUIRES` includes the `driver` co
 
 ## Example
 ```ruby
+include ESP32::Constants
 include ESP32::GPIO
 
 led = GPIO_NUM_4

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -1,7 +1,7 @@
 module ESP32
+  include Constants
+  
   module GPIO
-    include Constants
-    
     class << self
       alias :digital_write :digitalWrite   
       alias :digital_read  :digitalRead
@@ -12,11 +12,11 @@ module ESP32
   
     class Pin
       PIN_MODE = {
-        pullup:   ESP32::GPIO::INPUT_PULLUP,
-        pulldown: ESP32::GPIO::INPUT_PULLDOWN,
-        input:    ESP32::GPIO::INPUT,
-        output:   ESP32::GPIO::OUTPUT,
-        inout:    ESP32::GPIO::INPUT_OUTPUT
+        pullup:   ESP32::GPIO_MODE_INPUT_PULLUP,
+        pulldown: ESP32::GPIO_MODE_INPUT_PULLDOWN,
+        input:    ESP32::GPIO_MODE_INPUT,
+        output:   ESP32::GPIO_MODE_OUTPUT,
+        inout:    ESP32::GPIO_MODE_INPUT_OUTPUT
       }
 
       attr_reader :pin

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -2,6 +2,12 @@ module ESP32
   include Constants
   
   module GPIO
+    INPUT_PULLUP   = ESP32::GPIO_MODE_INPUT_PULLUP
+    INPUT_PULLDOWN = ESP32::GPIO_MODE_INPUT_PULLDOWN
+    INPUT          = ESP32::GPIO_MODE_INPUT
+    OUTPUT         = ESP32::GPIO_MODE_OUTPUT
+    INPUT_OUTPUT   = ESP32::GPIO_MODE_INPUT_OUTPUT
+    
     class << self
       alias :digital_write :digitalWrite   
       alias :digital_read  :digitalRead

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -3,11 +3,11 @@ module ESP32
     include Constants
     
     class << self
-      alias :digital_write :digitalWrite   
-      alias :digital_read  :digitalRead
-      alias :analog_write  :analogWrite   
-      alias :analog_read   :analogRead    
-      alias :pin_mode      :pinMode 
+      alias :pinMode      :pin_mode      
+      alias :digitalWrite :digital_write 
+      alias :digitalRead  :digital_read  
+      alias :analogWrite  :analog_write  
+      alias :analogRead   :analog_read   
     end  
   
     class Pin

--- a/mrblib/gpio.rb
+++ b/mrblib/gpio.rb
@@ -2,14 +2,6 @@ module ESP32
   module GPIO
     include Constants
     
-    class << self
-      alias :pinMode      :pin_mode      
-      alias :digitalWrite :digital_write 
-      alias :digitalRead  :digital_read  
-      alias :analogWrite  :analog_write  
-      alias :analogRead   :analog_read   
-    end  
-  
     class Pin
       PIN_MODE = {
         pullup:   ESP32::GPIO::INPUT_PULLUP,

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -102,11 +102,19 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   esp32 = mrb_define_module(mrb, "ESP32");
 
   gpio = mrb_define_module_under(mrb, esp32, "GPIO");
+  // Ruby-style snake case methods.
   mrb_define_module_function(mrb, gpio, "pin_mode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digital_write", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digital_read", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, gpio, "analog_write", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "analog_read", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
+
+  // Arduino-style camel case methods.
+  mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   
   adc1_config_width(ADC_BITWIDTH_12);
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -110,7 +110,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   
   adc1_config_width(ADC_BITWIDTH_12);
 
-  constants = mrb_define_module_under(mrb, gpio, "Constants");
+  constants = mrb_define_module_under(mrb, esp32, "Constants");
 
 #define define_const(SYM) \
   do { \
@@ -172,11 +172,11 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   mrb_define_const(mrb, constants, "LOW", mrb_fixnum_value(0));
   mrb_define_const(mrb, constants, "HIGH", mrb_fixnum_value(1));
 
-  mrb_define_const(mrb, constants, "INPUT",          mrb_fixnum_value(GPIO_MODE_INPUT));
-  mrb_define_const(mrb, constants, "INPUT_OUTPUT",   mrb_fixnum_value(GPIO_MODE_INPUT_OUTPUT));
-  mrb_define_const(mrb, constants, "OUTPUT",         mrb_fixnum_value(GPIO_MODE_OUTPUT));
-  mrb_define_const(mrb, constants, "INPUT_PULLUP",   mrb_fixnum_value(GPIO_MODE_INPUT_PULLUP));
-  mrb_define_const(mrb, constants, "INPUT_PULLDOWN", mrb_fixnum_value(GPIO_MODE_INPUT_PULLDOWN));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT",          mrb_fixnum_value(GPIO_MODE_INPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_OUTPUT",   mrb_fixnum_value(GPIO_MODE_INPUT_OUTPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_OUTPUT",         mrb_fixnum_value(GPIO_MODE_OUTPUT));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_PULLUP",   mrb_fixnum_value(GPIO_MODE_INPUT_PULLUP));
+  mrb_define_const(mrb, constants, "GPIO_MODE_INPUT_PULLDOWN", mrb_fixnum_value(GPIO_MODE_INPUT_PULLDOWN));
     
 }
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -167,6 +167,12 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb) {
     mrb_define_const(mrb, constants, #SYM, mrb_fixnum_value(SYM)); \
   } while (0)
 
+  //
+  // GPIO numbers available on each variant found here:
+  // https://github.com/espressif/esp-idf/blob/67552c31da/components/hal/include/hal/gpio_types.h
+  //
+  // All chips define GPIO_NUM_MAX and GPIO_NUM_0..GPIO_NUM_20.  
+  define_const(GPIO_NUM_MAX);
   define_const(GPIO_NUM_0);
   define_const(GPIO_NUM_1);
   define_const(GPIO_NUM_2);
@@ -187,24 +193,74 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb) {
   define_const(GPIO_NUM_17);
   define_const(GPIO_NUM_18);
   define_const(GPIO_NUM_19);
+  define_const(GPIO_NUM_20);
 
-  define_const(GPIO_NUM_21);
-  define_const(GPIO_NUM_22);
-  define_const(GPIO_NUM_23);
+  // Original, S2, S3, C3, C6 and H2 (all except C2) have 21.
+  #if defined(CONFIG_IDF_TARGET_ESP32)  || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3)|| defined(CONFIG_IDF_TARGET_ESP32C3) || \
+      defined(CONFIG_IDF_TARGET_ESP32C6)|| defined(CONFIG_IDF_TARGET_ESP32H2)      
+    define_const(GPIO_NUM_21);
+  #endif
+  
+  // Original, C6 and H2 have 22,23,25.
+  #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C6) || \
+      defined(CONFIG_IDF_TARGET_ESP32H2)
+    define_const(GPIO_NUM_22);
+    define_const(GPIO_NUM_23);
+    define_const(GPIO_NUM_25);
+  #endif
+    
+  // C6 and H2 have 24.
+  #if defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2)
+    define_const(GPIO_NUM_24);
+  #endif
+    
+  // Original, S2, S3, C6 ad H2 have 26,27.
+  #if defined(CONFIG_IDF_TARGET_ESP32)   || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6) || \
+      defined(CONFIG_IDF_TARGET_ESP32H2)
+    define_const(GPIO_NUM_26);
+    define_const(GPIO_NUM_27);
+  #endif
+    
+  // Original, S2, S3 and C6 have 28..30.
+  #if defined(CONFIG_IDF_TARGET_ESP32)   || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+    define_const(GPIO_NUM_28);
+    define_const(GPIO_NUM_29);
+    define_const(GPIO_NUM_30);
+  #endif
+    
+  // Original, S2 and S3 have 31..39.
+  #if defined(CONFIG_IDF_TARGET_ESP32)   || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3)
+    define_const(GPIO_NUM_31);    
+    define_const(GPIO_NUM_32);
+    define_const(GPIO_NUM_33);
+    define_const(GPIO_NUM_34);
+    define_const(GPIO_NUM_35);
+    define_const(GPIO_NUM_36);
+    define_const(GPIO_NUM_37);
+    define_const(GPIO_NUM_38);
+    define_const(GPIO_NUM_39);
+  #endif
 
-  define_const(GPIO_NUM_25);
-  define_const(GPIO_NUM_26);
-  define_const(GPIO_NUM_27);
+  // S2 and S3 have 40..46.
+  #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
+    define_const(GPIO_NUM_40);    
+    define_const(GPIO_NUM_41);
+    define_const(GPIO_NUM_42);
+    define_const(GPIO_NUM_43);
+    define_const(GPIO_NUM_44);
+    define_const(GPIO_NUM_45);
+    define_const(GPIO_NUM_46);
+  #endif
 
-  define_const(GPIO_NUM_32);
-  define_const(GPIO_NUM_33);
-  define_const(GPIO_NUM_34);
-  define_const(GPIO_NUM_35);
-  define_const(GPIO_NUM_36);
-  define_const(GPIO_NUM_37);
-  define_const(GPIO_NUM_38);
-  define_const(GPIO_NUM_39);
-  define_const(GPIO_NUM_MAX);
+  // S3 alone has 47,48.
+  #if defined(CONFIG_IDF_TARGET_ESP32S3)
+    define_const(GPIO_NUM_47);
+    define_const(GPIO_NUM_48);
+  #endif
 
   define_const(ADC_CHANNEL_0);
   define_const(ADC_CHANNEL_1);

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -263,20 +263,34 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb) {
     define_const(GPIO_NUM_48);
   #endif
 
-  // All chips define ADC_CHANNEL_0..ADC_CHANNEL_9
+  //
+  // All chips have ADC_CHANNEL_0..ADC_CHANNEL_9 defined, but limit them instead
+  // to the channels which are actually connected to GPIOs.
+  //
+  // All chips connect ADC_CHANNEL_0..ADC_CHANNEL_4 to a GPIO.
   define_const(ADC_CHANNEL_0);
   define_const(ADC_CHANNEL_1);
   define_const(ADC_CHANNEL_2);
   define_const(ADC_CHANNEL_3);
   define_const(ADC_CHANNEL_4);
-  define_const(ADC_CHANNEL_5);
-  define_const(ADC_CHANNEL_6);
-  define_const(ADC_CHANNEL_7);
-  // Channel 8 and 9 only on ADC2 for original ESP32, may work on ADC1 for others. Not sure.
-  define_const(ADC_CHANNEL_8);
-  define_const(ADC_CHANNEL_9);
 
-  // DAC available only on some chips.
+  // Original, S2, S3 and C6 have 5,6.
+  #if defined(CONFIG_IDF_TARGET_ESP32)   || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+    define_const(ADC_CHANNEL_5);
+    define_const(ADC_CHANNEL_6);
+  #endif
+
+  // Original, S2 and S3 have 7,8,9.
+  // Note: Original ESP32 has 8,9 only on ADC2 which isn't implemented yet.
+  #if defined(CONFIG_IDF_TARGET_ESP32)   || defined(CONFIG_IDF_TARGET_ESP32S2) || \
+      defined(CONFIG_IDF_TARGET_ESP32S3)
+    define_const(ADC_CHANNEL_7);
+    define_const(ADC_CHANNEL_8);
+    define_const(ADC_CHANNEL_9);
+  #endif
+
+  // Original and S2 have DACs.
   #ifdef SOC_DAC_SUPPORTED
     define_const(DAC_CHAN_0);
     define_const(DAC_CHAN_1);

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -112,7 +112,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   // Arduino-style camel case methods.
   mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -102,11 +102,11 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb)
   esp32 = mrb_define_module(mrb, "ESP32");
 
   gpio = mrb_define_module_under(mrb, esp32, "GPIO");
-  mrb_define_module_function(mrb, gpio, "pinMode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalWrite", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "digitalRead", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
-  mrb_define_module_function(mrb, gpio, "analogWrite", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
-  mrb_define_module_function(mrb, gpio, "analogRead", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, gpio, "pin_mode", mrb_esp32_gpio_pin_mode, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digital_write", mrb_esp32_gpio_digital_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "digital_read", mrb_esp32_gpio_digital_read, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, gpio, "analog_write", mrb_esp32_gpio_analog_write, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, gpio, "analog_read", mrb_esp32_gpio_analog_read, MRB_ARGS_REQ(1));
   
   adc1_config_width(ADC_BITWIDTH_12);
 

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -84,7 +84,8 @@ mrb_esp32_gpio_analog_read(mrb_state *mrb, mrb_value self) {
   };
   ESP_ERROR_CHECK(adc_oneshot_new_unit(&init_config1, &adc1_handle));
   
-  // Configuration. ADC_BITWIDTH_DEFAULT = 12
+  // Always use maximum resolution and attenuation.
+  // Should make this configurable.
   adc_oneshot_chan_cfg_t config = {
       .bitwidth = ADC_BITWIDTH_DEFAULT,
       .atten = ADC_ATTEN_DB_11,
@@ -262,6 +263,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb) {
     define_const(GPIO_NUM_48);
   #endif
 
+  // All chips define ADC_CHANNEL_0..ADC_CHANNEL_9
   define_const(ADC_CHANNEL_0);
   define_const(ADC_CHANNEL_1);
   define_const(ADC_CHANNEL_2);
@@ -270,7 +272,7 @@ mrb_mruby_esp32_gpio_gem_init(mrb_state* mrb) {
   define_const(ADC_CHANNEL_5);
   define_const(ADC_CHANNEL_6);
   define_const(ADC_CHANNEL_7);
-  // Channel 8 and 9 only exist on ADC2.
+  // Channel 8 and 9 only on ADC2 for original ESP32, may work on ADC1 for others. Not sure.
   define_const(ADC_CHANNEL_8);
   define_const(ADC_CHANNEL_9);
 


### PR DESCRIPTION
I want to use this with the ESP32-S2 and ESP32-S3. The interfaces are exactly the same, but preprocessor directives need to be used to make sure we're passing the right constants to mruby and avoid compilation errors.

This PR does that, and should handle the following variants: S2, S3, C2, C3, C6, H2, even though most of them won't even compile yet.

**Note:** I'm working from my fork, which includes my previous 3 PRs, so merging this would merge those too. The relevant commits here are the last 4.